### PR TITLE
Bump up to 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
+{% set sha256 = "965d4b8d0c5a13fd85db8e978582c071b4545d37c86503ca851c56449db22463" %}
 
 package:
   name: nc_time_axis
@@ -7,7 +8,7 @@ package:
 source:
   fn: nc-time-axis-{{ version }}.tar.gz
   url: https://github.com/SciTools/nc-time-axis/archive/v{{ version }}.tar.gz
-  sha256: d6a2a7d1e1b1aa3a1440f2d71e361f8f359155faf830b2884f069111bfc79dba
+  sha256: {{ sha256 }}
 
 build:
   number: 0


### PR DESCRIPTION
The latest release of nc_time_axis just includes a simple bug fix